### PR TITLE
Remove #! from Perl module

### DIFF
--- a/lib/Tk/FontDialog.pm
+++ b/lib/Tk/FontDialog.pm
@@ -1,4 +1,3 @@
-#!/usr/local/bin/perl -w
 # -*- perl -*-
 
 #


### PR DESCRIPTION
Hi

To package Tk::FontDIalog, I need to remove the first line (`#!/usr/local/bin/perl`). I cannot see any use for this line, so I suggest you do the same.

All the best